### PR TITLE
script to list INDI 3rd-party drivers available as Debian packages, retrieve versions, and fetch Git hashes

### DIFF
--- a/compare_debian_drivers.py
+++ b/compare_debian_drivers.py
@@ -198,17 +198,26 @@ if __name__ == "__main__":
 
                 # Get common drivers
                 common_drivers = get_common_drivers(drivers_list, debian_drivers)
-
-                # Print header
-                print(f"{'Driver':<25} | {'Version':<10} | {'Git Hash'}")
-                print("-" * 60)
                 
+                driver_results = {}
 
                 # Get the driver version
                 for driver in common_drivers:
                     debian_version = get_debian_version(driver)
                     debian_git_hash = process_package(driver)
-                    print(f"{driver:<25} | {debian_version:<10} | {debian_git_hash}")
+
+                                        # Save results in dictionary
+                    driver_results[driver] = {
+                        'version': debian_version,
+                        'git_hash': debian_git_hash
+                    }
+
+                # Print header
+                print(f"{'Driver':<25} | {'Version':<10} | {'Git Hash'}")
+                print("-" * 60)
+
+                for driver, details in driver_results.items():
+                    print(f"{driver:<25} | {details['version']:<10} | {details['git_hash']}")
             else:
                 print("Please install apt-cache to proceed.")
 

--- a/compare_debian_drivers.py
+++ b/compare_debian_drivers.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+
+import subprocess
+from pathlib import Path
+import git
+import shutil
+import re
+
+def check_apt_cache_installed():
+    """Check if apt-cache is available on the system."""
+    if shutil.which("apt-cache") is None:
+        print("Error: apt-cache is not installed or available on this system.")
+        return False
+    return True
+
+def clone_or_update_repo(repo_url, destination_path):
+    """
+    Clone the repo if it's not already cloned, or perform a git pull if it already exists.
+    
+    Args:
+        repo_url (str): URL of the repository.
+        destination_path (Path): Path to clone the repository.
+    
+    Returns:
+        bool: True if successful, False otherwise.
+    """
+    try:
+        if not destination_path.exists():
+            # Clone the repository if it doesn't exist
+            print(f"Cloning {repo_url} into {destination_path}...")
+            git.Repo.clone_from(repo_url, destination_path)
+        else:
+            # Perform a git pull if the repository already exists
+            repo = git.Repo(destination_path)
+            origin = repo.remotes.origin
+            origin.pull()
+            
+        return True
+    except Exception as e:
+        print(f"Failed to clone or update repository: {e}")
+        return False
+
+# Function to check if git is installed
+def check_git_installed():
+    """Check if git is available on the system."""
+    if shutil.which("git") is None:
+        print("Error: Git is not installed. Please install Git and try again.")
+        return False
+    return True
+
+# Function to list drivers from the 3rdparty repository
+def list_drivers(drivers_directory_path):
+    """List all the drivers in the repository.
+        Args: drivers_directory_path (Path): Path to the drivers directory.
+    """
+    try:
+        drivers = [item.name for item in drivers_directory_path.iterdir() if item.is_dir() and item.name.startswith("indi-")]
+        return drivers
+    except Exception as e:
+        print(f"Error occurred while listing drivers: {e}")
+        return []
+
+def get_debian_drivers():
+    """
+    Get a list of INDI drivers available as Debian packages.
+    
+    Returns:
+        list: A list of package names matching 'indi-*'.
+    """
+    try:
+        result = subprocess.run(['apt-cache', 'search', 'indi-'], stdout=subprocess.PIPE, text=True, check=True)
+        # Filter lines that start with 'indi-' to get package names
+        packages = [line.split()[0] for line in result.stdout.splitlines() if line.startswith('indi-')]
+        return packages
+    except subprocess.CalledProcessError as e:
+        print(f"Error occurred while fetching Debian drivers: {e}")
+        return []
+    
+def get_git_hash(repo_path, driver_path):
+    """Get the latest git hash of a driver using gitpython."""
+    try:
+        repo = git.Repo(repo_path)
+        driver_repo_path = str(repo_path / driver_path)
+        latest_commit = next(repo.iter_commits(paths=driver_repo_path, max_count=1))
+        return latest_commit.hexsha
+    except Exception as e:
+        print(f"Error fetching git hash for {driver_path}: {e}")
+        return "Git hash not found"
+
+def get_common_drivers(indi_third_party_drivers, debian_drivers):
+    """Get drivers that are available in both the 3rd-party repository and Debian packages.
+       Args:
+           indi_third_party_drivers (list): List of drivers from the 3rd-party repo.
+           debian_drivers (list): List of drivers available as Debian packages.
+       Returns:
+           list: Drivers found in both 3rd-party and Debian.
+    """
+    debian_set = set(debian_drivers)
+    third_party_set = set(indi_third_party_drivers)
+    common_drivers = third_party_set.intersection(debian_set)
+    return list(common_drivers)
+
+def get_debian_version(package_name):
+    """
+    Get the version of a specific Debian package, cleaning the version to remove timestamps and unnecessary suffixes.
+    
+    Args:
+        package_name (str): The name of the Debian package.
+    
+    Returns:
+        str: Cleaned version of the package or 'Version not found' if package not found.
+    """
+    try:
+        result = subprocess.run(['apt-cache', 'policy', package_name], stdout=subprocess.PIPE, text=True, check=True)
+        for line in result.stdout.splitlines():
+            if 'Candidate:' in line:
+                version = line.split()[1]
+                # Regular expression to match the version part (before the timestamp or other suffixes)
+                cleaned_version = re.match(r'[\d\.]+', version)
+                return cleaned_version.group(0) if cleaned_version else "Version not found"
+        return "Version not found"
+    except subprocess.CalledProcessError as e:
+        print(f"Error occurred while fetching version for {package_name}: {e}")
+        return "Version not found"
+
+def get_salsa_repo_url(package_name):
+    """
+    Construct a potential Salsa repository URL based on the package name.
+    Args:
+        package_name (str): The name of the Debian package.
+    
+    Returns:
+        str: The constructed Salsa Git repository URL.
+    """
+    return f"https://salsa.debian.org/debian-astro-team/{package_name}.git"
+
+def get_latest_git_hash(repo_path):
+    """
+    Get the latest git hash of a cloned repository.
+    Args:
+        repo_path (Path): The path to the cloned repository.
+    
+    Returns:
+        str: The latest git hash or an error message.
+    """
+    try:
+        repo = git.Repo(repo_path)
+        latest_commit = repo.head.commit.hexsha
+        return latest_commit
+    except Exception as e:
+        print(f"Error fetching git hash for {repo_path}: {e}")
+        return "Git hash not found"
+
+def process_package(package_name):
+    # Step 1: Construct the Git URL
+    repo_url = get_salsa_repo_url(package_name)
+    
+    # Step 2: Define the local path to clone the repository
+    repo_path = Path.home() / f"{package_name}-repo"
+    
+    # Step 3: Clone the repository if not already cloned
+    if clone_or_update_repo(repo_url, repo_path):
+        
+        # Step 4: Get the latest Git hash
+        git_hash = get_latest_git_hash(repo_path)
+        return git_hash
+    else:
+        print(f"Failed to process {package_name}")
+
+
+repo_url = 'https://github.com/indilib/indi-3rdparty.git'
+repo_path = Path.home() / 'indi-3rdparty'
+
+if __name__ == "__main__":
+    if check_git_installed():
+        # Clone the repository if it doesn't exist
+        if clone_or_update_repo(repo_url, repo_path):
+            drivers_directory_path = repo_path
+
+            # List drivers
+            drivers_list = list_drivers(drivers_directory_path)
+
+            if check_apt_cache_installed():
+                # list debian drivers
+                debian_drivers = get_debian_drivers()
+
+                # Get common drivers
+                common_drivers = get_common_drivers(drivers_list, debian_drivers)
+
+                # Print header
+                print(f"{'Driver':<25} | {'Version':<10} | {'Git Hash'}")
+                print("-" * 60)
+                
+
+                # Get the driver version
+                for driver in common_drivers:
+                    debian_version = get_debian_version(driver)
+                    debian_git_hash = process_package(driver)
+                    print(f"{driver:<25} | {debian_version:<10} | {debian_git_hash}")
+            else:
+                print("Please install apt-cache to proceed.")
+

--- a/compare_debian_drivers.py
+++ b/compare_debian_drivers.py
@@ -2,9 +2,16 @@
 
 import subprocess
 from pathlib import Path
-import git
 import shutil
 import re
+try:
+    import git
+except ModuleNotFoundError:
+    print("Error: The 'gitPython' module is not installed. Please install it by running 'pip install gitPython'.")
+    exit(1)
+
+repo_url = 'https://github.com/indilib/indi-3rdparty.git'
+repo_path = Path.home() / 'indi-3rdparty'
 
 def check_apt_cache_installed():
     """Check if apt-cache is available on the system."""
@@ -24,20 +31,26 @@ def clone_or_update_repo(repo_url, destination_path):
     Returns:
         bool: True if successful, False otherwise.
     """
+    destination_path = Path(destination_path)
+    print(f"Resolved destination path: {destination_path}")
+
     try:
         if not destination_path.exists():
             # Clone the repository if it doesn't exist
-            print(f"Cloning {repo_url} into {destination_path}...")
+            print(f"Cloning {repo_url} into {destination_path}. This may take a few moments...")
             git.Repo.clone_from(repo_url, destination_path)
+            print(f"Successfully cloned the repository into {destination_path}.")
         else:
             # Perform a git pull if the repository already exists
+            print(f"Updating the repository at {destination_path}...")
             repo = git.Repo(destination_path)
             origin = repo.remotes.origin
             origin.pull()
-            
+            print(f"Repository at {destination_path} is now up to date.")
+        
         return True
     except Exception as e:
-        print(f"Failed to clone or update repository: {e}")
+        print(f"Failed to clone or update the repository: {e}")
         return False
 
 # Function to check if git is installed
@@ -168,8 +181,7 @@ def process_package(package_name):
         print(f"Failed to process {package_name}")
 
 
-repo_url = 'https://github.com/indilib/indi-3rdparty.git'
-repo_path = Path.home() / 'indi-3rdparty'
+
 
 if __name__ == "__main__":
     if check_git_installed():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+gitpython


### PR DESCRIPTION
## Overview
This pull request implements **Task 2** of the project, which introduces a Python script to achieve the following:
1. **List all INDI 3rd-party drivers** available as Debian packages.
2. **Retrieve the corresponding Debian package version**.
3. **Fetch the latest Git hash** for the associated Salsa repository.

## Key Changes:
- **INDI 3rd-party Driver Listing**: The script filters and lists **INDI 3rd-party drivers** (matching `indi-*`) that are available as Debian packages by using `apt-cache search`.
- **Version Retrieval**: For each INDI 3rd-party driver found, the script queries the system to fetch the corresponding Debian package version.
- **Git Hash Fetching**: For each driver, the script constructs a potential Salsa Git repository URL, clones it locally if not already present, and retrieves the latest Git hash.

## Improvements:
- **Git Installation Check**: The script includes a check to ensure that `git` is installed on the system before proceeding with cloning operations.
- **Efficient Cloning**: If a repository already exists locally, the script checks its status and runs `git pull` to ensure it's up-to-date.
- **Enhanced Error Handling**: The script provides meaningful error messages in case of failures, such as missing packages, errors in version retrieval, or failed repository cloning.

## Edge Cases Handled:
- **Git Not Installed**: The script checks if `git` is installed and exits gracefully if it is not found.
- **Outdated Local Repository**: If the repository has been cloned before but is outdated, the script automatically runs `git pull` to update it.
- **No Debian Package Version**: For drivers without a found version, the script returns "Version not found" instead of failing.
- **No Git Hash**: If a Git hash cannot be retrieved, the script returns "Git hash not found" as a fallback.

## Testing
The script has been tested to ensure it performs as expected under various conditions, including:
- Listing INDI 3rd-party drivers correctly.
- Fetching the corresponding package version from Debian's package manager.
- Cloning repositories and retrieving the latest Git hash.
- Proper error handling and edge case management.

### Example Output:
```bash
Driver                    | Version    | Git Hash
------------------------------------------------------------
indi-astromechfoc         | 0.2        | 8583ebaadcdb9bcefc513786742ab41fd13e4f6e
indi-gpsd                 | 0.5        | 554ea0040fe84e78f643f34f79094073781efff9
indi-avalon               | 1.12       | cffd5f307e186ad86dcf7739390e8c97b8e84f2d
indi-rtklib               | 1.0        | cf8664f8b4a91fc94e3cf61993c65bee259dd17f
indi-ffmv                 | 0.3        | 001cfe0aa0d8af00bd986049f949f86743f8bf5e
indi-nightscape           | 1.0.6      | e3d661b318d927b172a173048935231ee97cd7c5
indi-gpsnmea              | 0.2        | ddfa28ce29df5f8449c018504389e98f56b840d9
indi-dreamfocuser         | 2.1        | b51c445a598b82a17adac439ece9cb568452ddbc
indi-starbook-ten         | 0.1        | ba7bd3ad986b7e2dc55a6867a544170845222bbf
indi-mi                   | 1.8        | 57b1b398613090561c6c54430f508414e61494f3
indi-playerone            | 0.4        | cd0cde720babb5cb33cca249932e5b2a50de138c
indi-gphoto               | 3.0        | e4307bbae64184797b9a8f11e8f13d88a6286262
indi-nexdome              | 1.5        | cd10e60e2e1ffba4d6be1c1651b33b57fb8e3e05
indi-apogee               | 1.9        | 85410dd301314fc920f13f317e0f3b641a5b7f39
indi-talon6               | 2.0        | 253ff9ee9339038715a350ae2e6f7379a79f4b06
indi-aagcloudwatcher-ng   | 1.6        | 5fe8e9a71388e1b4c2453906f454d7eac14f7a6e
indi-beefocus             | 0.1        | 2960ad4c92359e5f041f3843e2505f97a0948471
indi-starbook             | 0.8        | 72957b26a0b79c1fa12e9a511b9b5830a5e20de1
indi-sx                   | 1.15       | a0d1916db61ecc95f44701bb30001246e1e20b6a
indi-orion-ssg3           | 0.1        | 2a7024cc4f1aae1d9450b033a4a034e063464a28
indi-mgen                 | 0.1        | da8d83b7be42dad32f7c82bc804c13255597f43c
indi-limesdr              | 1.4        | 5f18f22fec8027676f0aba764c467025ad2b24d8
indi-gige                 | 0.1        | 0e0d22cb143863a2acc9a17b8be4bcb9f337d76d
indi-dsi                  | 0.4        | 04ea7de3e00e9c9522e07132da59bd8db3ded4f8
indi-aok                  | 1.1        | 59dc84f3e971e27d49ed9307734b0e959c6676e6
indi-astrolink4           | 0.1        | 03d2551a1680d4c373fd620f4567de3f9d40b976
indi-bresserexos2         | 1.0        | 92a05a726311bf22d32cebd894d4e5477474cd4b
indi-webcam               | 1.0        | 12d568f33be964d05463a9c5678f866eb92c10d8
indi-fli                  | 1.5        | 5d5c21821e59e1fda116f50e3ef37301930b3915
indi-spectracyber         | 1.3        | b3df0554625630da204507fef1f88561e8d02c4a
indi-armadillo-platypus   | 1.0        | ab33274870dd5bd9e6b4e3baf5adcd88f2f4d430
indi-fishcamp             | 1.1        | 1255477e2d2794bdee83a003bdf9a7c24ec8887b
indi-eqmod                | 1.0        | 0cc635b57173d5f79d60230a0f261ceb8fa84eb7
indi-shelyak              | 1.0        | 38236ce7005cc7f32cccd980a47ad88128d6e240
indi-asi                  | 2.0        | 955111d801401c8bff23c8eda6330714ed4a2dd8
indi-maxdomeii            | 1.3        | d9901e9ffe3a75c1b991fcbb62ae5ca6d1fdd638
```